### PR TITLE
incorporacion de funcion de exportar chats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,85 @@
+{
+  "name": "tero",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "moment": "^2.30.1"
+      },
+      "devDependencies": {
+        "@tsconfig/node22": "^22.0.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/moment": "^2.11.29",
+        "@types/node": "^25.0.1",
+        "@vue/tsconfig": "^0.8.1"
+      }
+    },
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/moment": {
+      "version": "2.11.29",
+      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.11.29.tgz",
+      "integrity": "sha512-D5WIgbLYQzvgfsDnBhZFSTnt/BjGPOE+Jsh3k1BYYijJAkrn7ceeLvU4jtjKKXXuXN42O3ARlU4D/P9ezbQYFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.1.tgz",
+      "integrity": "sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@vue/tsconfig": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.8.1.tgz",
+      "integrity": "sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "5.x",
+        "vue": "^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "moment": "^2.30.1"
+  },
+  "devDependencies": {
+    "@tsconfig/node22": "^22.0.5",
+    "@types/json-schema": "^7.0.15",
+    "@types/moment": "^2.11.29",
+    "@types/node": "^25.0.1",
+    "@vue/tsconfig": "^0.8.1"
+  }
+}

--- a/src/frontend/src/components/chat/ChatHeaderMenu.vue
+++ b/src/frontend/src/components/chat/ChatHeaderMenu.vue
@@ -3,16 +3,19 @@ import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Agent, Thread } from '@/services/api';
 import { useAgentStore } from '@/composables/useAgentStore';
-import { IconMessage2Plus, IconEditCircle, IconHistory, IconTrash, IconInfoCircle, IconCopyPlus } from '@tabler/icons-vue';
+import { useChatExport } from '@/composables/useChatExport';
+import { IconMessage2Plus, IconEditCircle, IconHistory, IconTrash, IconInfoCircle, IconCopyPlus, IconDownload } from '@tabler/icons-vue';
 import { useErrorHandler } from '@/composables/useErrorHandler';
 
 const { configureAgent, cloneAgent } = useAgentStore();
 const { handleError } = useErrorHandler();
+const { exportChatAsJson, exportChatAsMarkdown } = useChatExport();
 
 const props = defineProps<{
     agent: Agent,
     chat: Thread,
-    editingAgent?: boolean
+    editingAgent?: boolean,
+    messages?: any[]
 }>()
 const emit = defineEmits<{
     (e: 'showPastChats'): void
@@ -61,6 +64,17 @@ const handleCloneAgent = async () => {
   }
 }
 
+
+const handleExportAsJson = () => {
+  exportChatAsJson(props.chat, props.chat.name, agentName.value, props.messages ?? []);
+  closeMenu();
+}
+
+const handleExportAsMarkdown = () => {
+  exportChatAsMarkdown(props.chat, props.chat.name, agentName.value, props.messages ?? []);
+  closeMenu();
+}
+
 </script>
 <template>
   <div class="flex items-center gap-2 px-3 py-1.5 text-light-gray border border-auxiliar-gray rounded-2xl" :class="[{ '!bg-abstracta !text-white': menuIsActive }]">
@@ -99,6 +113,17 @@ const handleCloneAgent = async () => {
             label: t('cloneAgentTooltip'),
             tablerIcon: IconCopyPlus,
             command: handleCloneAgent
+          },
+          { separator: true },
+          {
+            label: t('exportChatAsJsonTooltip'),
+            tablerIcon: IconDownload,
+            command: handleExportAsJson
+          },
+          {
+            label: t('exportChatAsMarkdownTooltip'),
+            tablerIcon: IconDownload,
+            command: handleExportAsMarkdown
           },
           { separator: true },
           {
@@ -141,7 +166,9 @@ const handleCloneAgent = async () => {
       "newChatTooltip": "New chat",
       "editAgentTooltip": "Edit agent",
       "agentInfoTooltip": "View details",
-      "cloneAgentTooltip": "Clone agent"
+      "cloneAgentTooltip": "Clone agent",
+      "exportChatAsJsonTooltip": "Export as JSON",
+      "exportChatAsMarkdownTooltip": "Export as Markdown"
     },
     "es": {
       "deleteChatTooltip": "Eliminar chat",
@@ -153,7 +180,9 @@ const handleCloneAgent = async () => {
       "newChatTooltip": "Nuevo chat",
       "editAgentTooltip": "Editar agente",
       "agentInfoTooltip": "Ver detalles",
-      "cloneAgentTooltip": "Clonar agente"
-    }
+      "cloneAgentTooltip": "Clonar agente",
+      "exportChatAsJsonTooltip": "Exportar como JSON",
+      "exportChatAsMarkdownTooltip": "Exportar como Markdown",
+          }
   }
 </i18n>

--- a/src/frontend/src/components/chat/ChatPanel.vue
+++ b/src/frontend/src/components/chat/ChatPanel.vue
@@ -383,6 +383,7 @@ const handleViewFile = (file: UploadedFile) => {
         v-if="chat && agentsStore.currentAgent"
         :chat="chat"
         :agent="agentsStore.currentAgent"
+        :messages="messages"
         :editing-agent="editingAgent"
         @new-chat="onNewChat"
         @show-past-chats="onShowPastChats"

--- a/src/frontend/src/components/chat/ChatPanelHeader.vue
+++ b/src/frontend/src/components/chat/ChatPanelHeader.vue
@@ -9,7 +9,7 @@ const { deleteChat } = useChatStore();
 const { handleError } = useErrorHandler();
 const { t } = useI18n();
 
-defineProps<{chat: Thread, agent: Agent, editingAgent?: boolean}>()
+defineProps<{chat: Thread, agent: Agent, messages?: any[], editingAgent?: boolean}>()
 const emit = defineEmits(['newChat', 'showPastChats']);
 
 const handleChatDelete = async (chat: Thread)=>{
@@ -27,7 +27,7 @@ const handleChatDelete = async (chat: Thread)=>{
     <div class="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-3 w-full">
       <div class="flex items-center gap-2">
         <Animate :effect="AnimationEffect.FADE_IN">
-          <ChatHeaderMenu :agent="agent" :chat="chat" :editing-agent="editingAgent" @show-past-chats="emit('showPastChats')"
+          <ChatHeaderMenu :agent="agent" :chat="chat" :messages="messages" :editing-agent="editingAgent" @show-past-chats="emit('showPastChats')"
             @delete-chat="handleChatDelete" @new-chat="emit('newChat')"/>
         </Animate>
       </div>

--- a/src/frontend/src/composables/useChatExport.ts
+++ b/src/frontend/src/composables/useChatExport.ts
@@ -1,0 +1,45 @@
+import { ApiService, Thread } from '@/services/api'
+import { useErrorHandler } from './useErrorHandler'
+
+export function useChatExport() {
+  const api = new ApiService()
+  const { handleError } = useErrorHandler()
+
+  const validateMessagesForExport = (messages: any[] | undefined, errorMessage?: string): boolean => {
+    if (!messages || messages.length === 0) {
+      if (errorMessage) {
+        handleError(new Error(errorMessage))
+      }
+      return false
+    }
+    return true
+  }
+
+  const exportChatAsJson = (thread: Thread, threadName: string, agentName: string, messages: any[]): void => {
+    try {
+      if (!validateMessagesForExport(messages)) {
+        return
+      }
+      api.exportChatAsJson(thread.id, threadName, agentName, messages)
+    } catch (error) {
+      handleError(error)
+    }
+  }
+
+  const exportChatAsMarkdown = (thread: Thread, threadName: string, agentName: string, messages: any[]): void => {
+    try {
+      if (!validateMessagesForExport(messages)) {
+        return
+      }
+      api.exportChatAsMarkdown(thread.id, threadName, agentName, messages)
+    } catch (error) {
+      handleError(error)
+    }
+  }
+
+  return {
+    exportChatAsJson,
+    exportChatAsMarkdown,
+    validateMessagesForExport
+  }
+}

--- a/src/frontend/tsconfig.app.json
+++ b/src/frontend/tsconfig.app.json
@@ -16,9 +16,12 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
-    }
+      "@/*": ["./src/*"]
+    },
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "experimentalDecorators": true
   }
 }


### PR DESCRIPTION
La nueva funcionalidad de exportar chats permite a los usuarios guardar las conversaciones mantenidas con los agentes en diferentes formatos, facilitando así la documentación, el análisis y el intercambio de información relevante. Ahora es posible exportar el historial de chat tanto en formato Markdown (MD) como en JSON, lo que brinda flexibilidad para utilizar los datos en reportes, presentaciones o integraciones con otras herramientas.

Las acciones se encuentran en

<img width="424" height="362" alt="Image" src="https://github.com/user-attachments/assets/0658a40c-c74e-4465-99ae-431c4ab2e95b" />