### PR TITLE
Fix docs gh-pages deploy by allowing esbuild builds on pnpm 11

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+packages:
+  - "."
+
+allowBuilds:
+  esbuild: true
+  sharp: true
+  "@parcel/watcher": true

--- a/src/package.json
+++ b/src/package.json
@@ -48,6 +48,5 @@
     "unplugin-vue-components": "^28.8.0",
     "vite": "^6.3.5",
     "vue-tsc": "^2.2.12"
-  },
-  "packageManager": "pnpm@10.29.1+sha512.48dae233635a645768a3028d19545cacc1688639eeb1f3734e42d6d6b971afbf22aa1ac9af52a173d9c3a20c15857cfa400f19994d79a2f626fcc73fccda9bbc"
+  }
 }


### PR DESCRIPTION
Fixes gh-pages deploy after pnpm 11 upgrade by allowing esbuild build scripts in docs/. Also removes an accidental packageManager pin from src/package.json.